### PR TITLE
Optimizations and important bug fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1365,7 +1365,6 @@
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -1746,7 +1745,6 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/handlebars": {
@@ -4129,7 +4127,6 @@
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/esutils": {
@@ -8660,7 +8657,6 @@
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -8869,8 +8865,9 @@
     },
     "node_modules/react": {
       "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9411,7 +9408,7 @@
     },
     "node_modules/rollup": {
       "version": "4.13.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.5"
@@ -11338,11 +11335,11 @@
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
+        "@rollup/pluginutils": "^5.1.0",
         "handlebars": "^4.7.8",
         "ramda": "^0.28.0"
       },
       "devDependencies": {
-        "@rollup/pluginutils": "^5.1.0",
         "@types/handlebars": "^4.1.0",
         "@types/node": "^20.12.2",
         "@types/ramda": "^0.28.11",

--- a/packages/ts-loader/src/index.ts
+++ b/packages/ts-loader/src/index.ts
@@ -29,7 +29,6 @@ function loader(content: string, sourceMap: string, meta: SharedData) {
       className,
       componentName,
       isExtended: tagName && (parsedProperties || parsedVariables) && true,
-      isStyled: !tagName,
       properties: parsedProperties,
       propsType: propsType(componentName, this.resource),
       styledPropsType: styledPropsType(componentName),
@@ -37,11 +36,10 @@ function loader(content: string, sourceMap: string, meta: SharedData) {
       variables: parsedVariables,
     }
   })
-  const isRestyled = exports.some(({isStyled}) => isStyled)
 
   writeFile(
     nameFile(this.resource),
-    toDTS({isRestyled, exports}),
+    toDTS({exports}),
     error => error && this.emitWarning(error),
   )
 

--- a/packages/ts-loader/src/template.hbs
+++ b/packages/ts-loader/src/template.hbs
@@ -2,12 +2,10 @@ import {FC, ComponentProps} from 'react'
 
 {{#each exports}}
 {{#with this}}
-{{#if isStyled}}
 interface {{styledPropsType}} {
   {{properties}}
   {{variables}}
 }
-{{else}}
 
 {{#if isExtended}}
 export interface {{propsType}} extends ComponentProps<'{{tagName}}'> {
@@ -18,17 +16,13 @@ export declare const {{componentName}}: FC<{{propsType}}>
 {{else}}
 export declare const {{componentName}}: FC<ComponentProps<'{{tagName}}'>>
 {{/if}}
-{{/if}}
 {{/with}}
 {{/each}}
 
-{{#if isRestyled}}
 interface ClassName {
 {{#each exports}}
 {{#with this}}
-{{#if isStyled}}
   '{{className}}' : {{styledPropsType}}
-{{/if}}
 {{/with}}
 {{/each}}
 }
@@ -36,4 +30,3 @@ interface ClassName {
 type ApplyStyle = <C extends keyof ClassName, P>(className: C, Component: FC<P>) => FC<P & ClassName[C]>
 
 export declare const applyStyle: ApplyStyle
-{{/if}}

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -42,6 +42,7 @@ export default defineConfig({
   plugins: [stylin(), stylinTS(), otherPlugin()]
 })
 ```
+> **Make sure to put the Typescript plugin *after* the base plugin.**
 
 This plugin detects files that end with `.module.css` or `.module.scss` in your project and creates matching `.d.ts` files alongside them. For example, if your source code directory has this structure:
 ```

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -48,7 +48,6 @@
     "watch": "tsc -w"
   },
   "devDependencies": {
-    "@rollup/pluginutils": "^5.1.0",
     "@types/handlebars": "^4.1.0",
     "@types/node": "^20.12.2",
     "@types/ramda": "^0.28.11",
@@ -59,6 +58,7 @@
     "vite": "^5.2.7"
   },
   "dependencies": {
+    "@rollup/pluginutils": "^5.1.0",
     "handlebars": "^4.7.8",
     "ramda": "^0.28.0"
   },

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -8,7 +8,7 @@ function stringify(o: Object) {
   return JSON.stringify(o)
 }
 
-type ResultCacheValue = { msa: MSA[] };
+type ResultCacheValue = { msa: MSA[] }
 export const resultCache = new Map<string, ResultCacheValue>()
 
 const filter = createFilter(/\.module\.s?css$/)
@@ -51,6 +51,15 @@ $1`)}`
           map: {mappings: ``}
         }
       }
-    }
+    },
+
+    async handleHotUpdate(ctx) {
+      const id = ctx.file
+      const code = await ctx.read()
+      if (filter(id)) {
+        const {msa} = compileCSS({id, code})
+        resultCache.set(id, {msa})
+      }
+    },
   }
 }

--- a/packages/vite-plugin/src/template.hbs
+++ b/packages/vite-plugin/src/template.hbs
@@ -2,12 +2,10 @@ import {FC, ComponentProps} from 'react'
 
 {{#each exports}}
 {{#with this}}
-{{#if isStyled}}
 interface {{styledPropsType}} {
   {{properties}}
   {{variables}}
 }
-{{else}}
 
 {{#if isExtended}}
 export interface {{propsType}} extends ComponentProps<'{{tagName}}'> {
@@ -18,17 +16,13 @@ export declare const {{componentName}}: FC<{{propsType}}>
 {{else}}
 export declare const {{componentName}}: FC<ComponentProps<'{{tagName}}'>>
 {{/if}}
-{{/if}}
 {{/with}}
 {{/each}}
 
-{{#if isRestyled}}
 interface ClassName {
 {{#each exports}}
 {{#with this}}
-{{#if isStyled}}
   '{{className}}' : {{styledPropsType}}
-{{/if}}
 {{/with}}
 {{/each}}
 }
@@ -36,4 +30,3 @@ interface ClassName {
 type ApplyStyle = <C extends keyof ClassName, P>(className: C, Component: FC<P>) => FC<P & ClassName[C]>
 
 export declare const applyStyle: ApplyStyle
-{{/if}}


### PR DESCRIPTION
## Changes
1. Moved `@rollup/pluginutils` to `dependencies` since it is used by both the base plugin and the Typescript plugin to determine which files should be transformed.
2. Added `handleHotUpdate` hook. Previously, the plugin only implemented the `transform` hook to compile CSS modules. However, the `transform` hook is only called **after** the module has been imported and used on the page (i.e., when Vite recognizes that the module should be included in the final bundle). That means that the user will not get auto-completion for the exports of the compiled module until after the first rendering of the module's components on the page. The added hook detects changes as soon as the module file has changed and compiles the file immediately, making sure that auto-complete works as expected.
3. Removed `isStyled` and `isRestyled` flags from the Typescript template since the `applyStyle` method is always exported regardless of whether the `@tag` directive is present.